### PR TITLE
Make WorldMgr Getobjects Generic

### DIFF
--- a/GameServer/commands/admincommands/Reload.cs
+++ b/GameServer/commands/admincommands/Reload.cs
@@ -211,7 +211,7 @@ namespace DOL.GS.Commands
 
 			int count = 0;
 
-			foreach (GameNPC mob in WorldMgr.GetNPCsFromRegion(region))
+			foreach (GameNPC mob in WorldMgr.GetobjectsFromRegion<GameNPC>(region))
 			{
 				if (!mob.LoadedFromScript)
 				{
@@ -295,7 +295,7 @@ namespace DOL.GS.Commands
 				return;
 			}
 
-			foreach (GameStaticItem staticItem in WorldMgr.GetStaticItemFromRegion(region))
+			foreach (GameStaticItem staticItem in WorldMgr.GetobjectsFromRegion<GameStaticItem>(region))
 			{
 				if (!staticItem.LoadedFromScript)
 				{

--- a/GameServer/commands/gmcommands/jump.cs
+++ b/GameServer/commands/gmcommands/jump.cs
@@ -118,7 +118,7 @@ namespace DOL.GS.Commands
 
 					if (clientc == null)
 					{
-						GameNPC[] npcs = WorldMgr.GetNPCsByName(args[2], eRealm.None);
+						GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>(args[2], eRealm.None);
 
 						if (npcs.Length > 0)
 						{
@@ -175,7 +175,7 @@ namespace DOL.GS.Commands
 						int realm = 0;
 						int.TryParse(args[3], out realm);
 
-						GameNPC[] npcs = WorldMgr.GetNPCsByName(args[2], (eRealm)realm);
+						GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>(args[2], (eRealm)realm);
 
 						if (npcs.Length > 0)
 						{

--- a/GameServer/commands/gmcommands/mob.cs
+++ b/GameServer/commands/gmcommands/mob.cs
@@ -2946,7 +2946,7 @@ namespace DOL.GS.Commands
 				// Reload the mob(s)
 				for (eRealm i = eRealm._First; i <= eRealm._Last; i++)
 				{
-					mobs.Add(WorldMgr.GetNPCsByName(args[2], i));
+					mobs.Add(WorldMgr.GetObjectsByName<GameNPC>(args[2], i));
 				}
 				foreach (GameNPC[] ma in mobs)
 				{

--- a/GameServer/commands/playercommands/where.cs
+++ b/GameServer/commands/playercommands/where.cs
@@ -39,7 +39,7 @@ namespace DOL.GS.Commands
 			if (targetnpc != null && CheckTargetIsGuard(targetnpc))
 			{
 				string name = String.Join(" ", args, 1, args.Length - 1);
-				GameNPC[] npcs = WorldMgr.GetNPCsByNameFromRegion(name, client.Player.CurrentRegionID, (eRealm) client.Player.Realm);
+				GameNPC[] npcs = WorldMgr.GetObjectsByNameFromRegion<GameNPC>(name, client.Player.CurrentRegionID, client.Player.Realm);
 				if (npcs == null || npcs.Length <= 0)
 				{
 					targetnpc.SayTo(client.Player, "Sorry, i do not know this person.");

--- a/GameServer/quests/Atlantis/ArtifactQuest.cs
+++ b/GameServer/quests/Atlantis/ArtifactQuest.cs
@@ -87,21 +87,21 @@ namespace DOL.GS.Quests.Atlantis
 					{
 						case eRealm.Albion:
 							title = "Scholar";
-							npcs = WorldMgr.GetNPCsByName(String.Format("{0} {1}", title, scholar), realm);
+							npcs = WorldMgr.GetObjectsByName<GameNPC>(String.Format("{0} {1}", title, scholar), realm);
 							break;
 						case eRealm.Midgard:
 							title = "Loremaster";
-							npcs = WorldMgr.GetNPCsByName(String.Format("{0} {1}", title, scholar), realm);
+							npcs = WorldMgr.GetObjectsByName<GameNPC>(String.Format("{0} {1}", title, scholar), realm);
 
 							if (npcs.Length == 0)
 							{
 								title = "Loremistress";
-								npcs = WorldMgr.GetNPCsByName(String.Format("{0} {1}", title, scholar), realm);
+								npcs = WorldMgr.GetObjectsByName<GameNPC>(String.Format("{0} {1}", title, scholar), realm);
 							}
 							break;
 						case eRealm.Hibernia:
 							title = "Sage";
-							npcs = WorldMgr.GetNPCsByName(String.Format("{0} {1}", title, scholar), realm);
+							npcs = WorldMgr.GetObjectsByName<GameNPC>(String.Format("{0} {1}", title, scholar), realm);
 							break;
 						default:
 							title = "<unknown title>";

--- a/GameServer/quests/Atlantis/ArtifactTurnInQuest.cs
+++ b/GameServer/quests/Atlantis/ArtifactTurnInQuest.cs
@@ -169,7 +169,7 @@ namespace DOL.GS.Quests.Atlantis
 
 			#region defineNPCs
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "ArtifactTurnInQuest.Init.ArtifactScholarFemale") + " Alaria", eRealm.Midgard);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "ArtifactTurnInQuest.Init.ArtifactScholarFemale") + " Alaria", eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				m_scholarAlaria = new ArtifactScholar();
@@ -194,7 +194,7 @@ namespace DOL.GS.Quests.Atlantis
 			else
 				m_scholarAlaria = npcs[0] as ArtifactScholar;
 
-			npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "ArtifactTurnInQuest.Init.ArtifactScholarMale") + " Jarron", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "ArtifactTurnInQuest.Init.ArtifactScholarMale") + " Jarron", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				m_scholarJarron = new ArtifactScholar();
@@ -219,7 +219,7 @@ namespace DOL.GS.Quests.Atlantis
 			else
 				m_scholarJarron = npcs[0] as ArtifactScholar;
 
-			npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "ArtifactTurnInQuest.Init.ArtifactScholarMale") + " Elmer", eRealm.Hibernia);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "ArtifactTurnInQuest.Init.ArtifactScholarMale") + " Elmer", eRealm.Hibernia);
 			if (npcs.Length == 0)
 			{
 				m_scholarElmer = new ArtifactScholar();

--- a/GameServer/quests/QuestsMgr/QuestMgr.cs
+++ b/GameServer/quests/QuestsMgr/QuestMgr.cs
@@ -145,7 +145,7 @@ namespace DOL.GS.Quests
                 // TODO: Dirty Hack this should be done better
                 Mob mob = GameServer.Database.SelectObjects<Mob>("`Mob_ID` = @MobID OR `Name` = @Name", new[] { new QueryParameter("@MobID", tempID), new QueryParameter("@Name", tempID) }).FirstOrDefault();
 
-                GameNPC[] livings = WorldMgr.GetNPCsByName(mob.Name,(eRealm) mob.Realm);
+                GameNPC[] livings = WorldMgr.GetObjectsByName<GameNPC>(mob.Name,(eRealm) mob.Realm);
 
                 if (livings.Length == 1)
                     living = livings[0];
@@ -208,7 +208,7 @@ namespace DOL.GS.Quests
 
                 Mob mob = GameServer.Database.SelectObjects<Mob>("`Mob_ID` = @MobID OR `Name` = @Name", new[] { new QueryParameter("@MobID", tempID), new QueryParameter("@Name", tempID) }).FirstOrDefault();
 
-				GameNPC[] npcs = WorldMgr.GetNPCsByName(mob.Name,(eRealm) mob.Realm);
+				GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>(mob.Name,(eRealm) mob.Realm);
 
                 if (npcs.Length == 1)
                 {

--- a/GameServer/world/WorldMgr.cs
+++ b/GameServer/world/WorldMgr.cs
@@ -21,7 +21,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection;
 using System.Threading;
 using Timer=System.Threading.Timer;
@@ -29,9 +28,6 @@ using Timer=System.Threading.Timer;
 using DOL.Database;
 using DOL.GS.PacketHandler;
 using DOL.GS.Utils;
-using DOL.Config;
-using DOL.GS.Housing;
-
 using log4net;
 
 namespace DOL.GS
@@ -229,77 +225,6 @@ namespace DOL.GS
 		/// clients after a certain intervall;
 		/// </summary>
 		private static Timer m_dayResetTimer;
-
-		/// <summary>
-		/// Region ID INI field
-		/// </summary>
-		private const string ENTRY_REG_ID = "id";
-		/// <summary>
-		/// Region IP INI field
-		/// </summary>
-		private const string ENTRY_REG_IP = "ip";
-		/// <summary>
-		/// Region port INI field
-		/// </summary>
-		private const string ENTRY_REG_PORT = "port";
-		/// <summary>
-		/// Region description INI field
-		/// </summary>
-		private const string ENTRY_REG_DESC = "description";
-		/// <summary>
-		/// Region diving enable INI field
-		/// </summary>
-		private const string ENTRY_REG_DIVING_ENABLE = "isDivingEnabled";
-		/// <summary>
-		/// Region diving enable INI field
-		/// </summary>
-		private const string ENTRY_REG_HOUSING_ENABLE = "isHousingEnabled";
-		/// <summary>
-		/// Region water level INI field
-		/// </summary>
-		private const string ENTRY_REG_WATER_LEVEL = "waterLevel";
-		/// <summary>
-		/// Region expansion INI field
-		/// </summary>
-		private const string ENTRY_REG_EXPANSION = "expansion";
-
-		/// <summary>
-		/// Zone ID INI field
-		/// </summary>
-		private const string ENTRY_ZONE_ZONEID = "zoneID";
-		/// <summary>
-		/// Zone region INI field
-		/// </summary>
-		private const string ENTRY_ZONE_REGIONID = "regionID";
-		/// <summary>
-		/// Zone description INI field
-		/// </summary>
-		private const string ENTRY_ZONE_DESC = "description";
-		/// <summary>
-		/// Zone X offset INI field
-		/// </summary>
-		private const string ENTRY_ZONE_OFFX = "offsetx";
-		/// <summary>
-		/// Zone Y offset INI field
-		/// </summary>
-		private const string ENTRY_ZONE_OFFY = "offsety";
-		/// <summary>
-		/// Zone width INI field
-		/// </summary>
-		private const string ENTRY_ZONE_WIDTH = "width";
-		/// <summary>
-		/// Zone height INI field
-		/// </summary>
-		private const string ENTRY_ZONE_HEIGHT = "height";
-		/// <summary>
-		/// Zone water level INI field
-		/// </summary>
-		private const string ENTRY_ZONE_WATER_LEVEL = "waterlevel";
-		
-		/// <summary>
-		/// Does this zone contain Lava
-		/// </summary>
-		private const string ENTRY_ZONE_LAVA = "IsLava";
 
 		/// <summary>
 		/// Relocation threads for relocation of zones
@@ -785,13 +710,6 @@ namespace DOL.GS
 			return Util.GetThreadStack(m_WorldUpdateThread);
 		}
 
-		private static uint m_lastWorldObjectUpdateTick = 0;
-		
-		public static uint LastWorldObjectUpdateTick {
-			get { return m_lastWorldObjectUpdateTick; }
-			set { m_lastWorldObjectUpdateTick = value; }
-		}
-
 		/// <summary>
 		/// Cleans up and stops all the RegionMgr tasks inside
 		/// the regions.
@@ -1023,74 +941,39 @@ namespace DOL.GS
 				}
 			}
 			return -1;
-		}
-		
-		public static object[] OfTypeAndToArray<T>(this IEnumerable<T> input, Type type)
-		{
-			MethodInfo methodOfType = typeof(Enumerable).GetMethod("OfType");
-			MethodInfo genericOfType = methodOfType.MakeGenericMethod(new Type[]{ type });
-			// Use .NET 4 covariance
-			var result = (IEnumerable<object>) genericOfType.Invoke(null, new object[] { input });
-			
-			MethodInfo methodToArray = typeof(Enumerable).GetMethod("ToArray");
-			MethodInfo genericToArray = methodToArray.MakeGenericMethod(new Type[]{ type });
-			
-			return (object[]) genericToArray.Invoke(null, new object[] { result });
-		}
+	    }
 
-		/// <summary>
-		/// Searches for all objects from a specific region
-		/// </summary>
-		/// <param name="regionID">The region to search</param>
-		/// <param name="objectType">The type of the object you search</param>
-		/// <returns>All objects with the specified parameters</returns>
-		public static GameObject[] GetobjectsFromRegion(ushort regionID, Type objectType)
+        /// <summary>
+        /// Searches for all objects from a specific region
+        /// </summary>
+        /// <param name="regionId">The region to search</param>
+        /// <param name="objectType">The type of the object you search</param>
+        /// <returns>All objects with the specified parameters</returns>
+        public static T[] GetobjectsFromRegion<T>(ushort regionId)
+            where T : GameObject
 		{
-			Region reg;
-			if (!m_regions.TryGetValue(regionID, out reg))
-				return new GameObject[0];
+		    if (!m_regions.TryGetValue(regionId, out var reg))
+		    {
+		        return new T[0];
+            }
 
-			return (GameObject[]) reg.Objects.Where(obj => obj != null).OfTypeAndToArray(objectType);
-		}
-		
-		/// <summary>
-		/// Searches for all GameStaticItem from a specific region
-		/// </summary>
-		/// <param name="regionID">The region to search</param>
-		/// <returns>All NPCs with the specified parameters</returns>
-		public static GameStaticItem[] GetStaticItemFromRegion(ushort regionID)
-		{
-			return (GameStaticItem[])GetobjectsFromRegion(regionID, typeof(GameStaticItem));
+			return reg.Objects.Where(obj => obj != null).OfType<T>().ToArray();
 		}
 
 		/// <summary>
 		/// Searches for all objects with the given name, from a specific region and realm
 		/// </summary>
 		/// <param name="name">The name of the object to search</param>
-		/// <param name="regionID">The region to search</param>
+		/// <param name="regionId">The region to search</param>
 		/// <param name="realm">The realm of the object we search!</param>
 		/// <param name="objectType">The type of the object you search</param>
 		/// <returns>All objects with the specified parameters</returns>
-		public static GameObject[] GetObjectsByNameFromRegion(string name, ushort regionID, eRealm realm, Type objectType)
+		public static T[] GetObjectsByNameFromRegion<T>(string name, ushort regionId, eRealm realm)
+            where T : GameObject
 		{
-			Region reg;
-			if (!m_regions.TryGetValue(regionID, out reg))
-				return new GameObject[0];
-			
-			return (GameObject[]) reg.Objects.Where(obj => obj != null && obj.Realm == realm && obj.Name == name).OfTypeAndToArray(objectType);
-		}
-
-		/// <summary>
-		/// Returns the npcs in a given region
-		/// </summary>
-		/// <returns></returns>
-		public static GameNPC[] GetNPCsFromRegion(ushort regionID)
-		{
-			Region reg;
-			if (!m_regions.TryGetValue(regionID, out reg))
-				return new GameNPC[0];
-
-			return reg.Objects.OfType<GameNPC>().ToArray();
+			return GetobjectsFromRegion<T>(regionId)
+                .Where(obj => obj.Realm == realm && obj.Name == name)
+                .ToArray();
 		}
 
 		/// <summary>
@@ -1100,73 +983,13 @@ namespace DOL.GS
 		/// <param name="realm">The realm of the object we search!</param>
 		/// <param name="objectType">The type of the object you search</param>
 		/// <returns>All objects with the specified parameters</returns>b
-		public static GameObject[] GetObjectsByName(string name, eRealm realm, Type objectType)
+		public static T[] GetObjectsByName<T>(string name, eRealm realm)
+            where T : GameObject
 		{
-			return (GameObject[]) m_regions.Values.Select(reg => GetObjectsByNameFromRegion(name, reg.ID, realm, objectType))
-				.SelectMany(objs => objs).OfTypeAndToArray(objectType);
-		}
-
-		/// <summary>
-		/// Searches for all NPCs with the given name, from a specific region and realm
-		/// </summary>
-		/// <param name="name">The name of the object to search</param>
-		/// <param name="regionID">The region to search</param>
-		/// <param name="realm">The realm of the object we search!</param>
-		/// <returns>All NPCs with the specified parameters</returns>
-		public static GameNPC[] GetNPCsByNameFromRegion(string name, ushort regionID, eRealm realm)
-		{
-			return (GameNPC[])GetObjectsByNameFromRegion(name, regionID, realm, typeof(GameNPC));
-		}
-
-		/// <summary>
-		/// Searches for all NPCs with the given name and realm in ALL regions!
-		/// </summary>
-		/// <param name="name">The name of the object to search</param>
-		/// <param name="realm">The realm of the object we search!</param>
-		/// <returns>All NPCs with the specified parameters</returns>b
-		public static GameNPC[] GetNPCsByName(string name, eRealm realm)
-		{
-			return (GameNPC[])GetObjectsByName(name, realm, typeof(GameNPC));
-		}
-
-		/// <summary>
-		/// Searches for all NPCs with the given guild and realm in ALL regions!
-		/// </summary>
-		/// <param name="guild">The guild name for the npc</param>
-		/// <param name="realm">The realm of the npc</param>
-		/// <returns>A collection of NPCs which match the result</returns>
-		public static List<GameNPC> GetNPCsByGuild(string guild, eRealm realm)
-		{
-			return m_regions.Values.Select(r => r.Objects.OfType<GameNPC>().Where(npc => npc.Realm == realm && npc.GuildName == guild))
-				.SelectMany(objs => objs).ToList();
-		}
-
-		/// <summary>
-		/// Searches for all NPCs with the given type and realm in ALL regions!
-		/// </summary>
-		/// <param name="type"></param>
-		/// <param name="realm"></param>
-		/// <returns></returns>
-		public static List<GameNPC> GetNPCsByType(Type type, eRealm realm)
-		{
-			return m_regions.Values.Select(r => r.Objects.OfType<GameNPC>().Where(npc => npc.Realm == realm && type.IsInstanceOfType(npc)))
-				.SelectMany(objs => objs).ToList();
-		}
-
-		/// <summary>
-		/// Searches for all NPCs with the given type and realm in a specific region
-		/// </summary>
-		/// <param name="type"></param>
-		/// <param name="realm"></param>
-		/// <param name="region"></param>
-		/// <returns></returns>
-		public static List<GameNPC> GetNPCsByType(Type type, eRealm realm, ushort region)
-		{
-			Region reg;
-			if (!m_regions.TryGetValue(region, out reg))
-				return new List<GameNPC>(0);
-			
-			return reg.Objects.OfType<GameNPC>().Where(npc => npc.Realm == realm && type.IsInstanceOfType(npc)).ToList();
+			return m_regions.Values
+                .Select(reg => GetObjectsByNameFromRegion<T>(name, reg.ID, realm))
+				.SelectMany(objs => objs)
+                .ToArray();
 		}
 
 		/// <summary>
@@ -1231,173 +1054,6 @@ namespace DOL.GS
 				return;
 			//client.Player.RemoveFromWorld();
 			client.Player.Delete();
-			return;
-		}
-
-		//Various functions to get a list of players/mobs/items
-		#region getdistance
-		/// <summary>
-		/// Get's the distance of two GameObjects
-		/// </summary>
-		/// <param name="obj1">Object1</param>
-		/// <param name="obj2">Object2</param>
-		/// <returns>The distance in units or -1 if they are not the same Region</returns>
-		[Obsolete( "Use Point3D.GetDistance" )]
-		public static int GetDistance( GameObject obj1, GameObject obj2 )
-		{
-			if ( obj1 == null || obj2 == null || obj1.CurrentRegion != obj2.CurrentRegion )
-				return -1;
-			return GetDistance( obj1.X, obj1.Y, obj1.Z, obj2.X, obj2.Y, obj2.Z );
-		}
-
-		/// <summary>
-		/// Get's the distance of two GameObjects
-		/// </summary>
-		/// <param name="obj1">Object1</param>
-		/// <param name="obj2">Object2</param>
-		/// <param name="zfactor">Factor for Z distance use lower 0..1 to lower Z influence</param>
-		/// <returns>The distance in units or -1 if they are not the same Region</returns>
-		[Obsolete( "Use Point3D.GetDistance" )]
-		public static int GetDistance( GameObject obj1, GameObject obj2, double zfactor )
-		{
-			if ( obj1 == null || obj2 == null || obj1.CurrentRegion != obj2.CurrentRegion )
-				return -1;
-			return GetDistance( obj1.X, obj1.Y, obj1.Z, obj2.X, obj2.Y, obj2.Z, zfactor );
-		}
-
-		/// <summary>
-		/// Gets the distance of two arbitary points in space
-		/// </summary>
-		/// <param name="x1">X of Point1</param>
-		/// <param name="y1">Y of Point1</param>
-		/// <param name="z1">Z of Point1</param>
-		/// <param name="x2">X of Point2</param>
-		/// <param name="y2">Y of Point2</param>
-		/// <param name="z2">Z of Point2</param>
-		/// <returns>The distance</returns>
-		[Obsolete( "Use Point3D.GetDistance" )]
-		public static int GetDistance( int x1, int y1, int z1, int x2, int y2, int z2 )
-		{
-			long xdiff = (long)x1 - x2;
-			long ydiff = (long)y1 - y2;
-
-			long zdiff = (long)z1 - z2;
-			return (int)Math.Sqrt( xdiff * xdiff + ydiff * ydiff + zdiff * zdiff );
-		}
-
-		/// <summary>
-		/// Gets the distance of two arbitary points in space
-		/// </summary>
-		/// <param name="x1">X of Point1</param>
-		/// <param name="y1">Y of Point1</param>
-		/// <param name="z1">Z of Point1</param>
-		/// <param name="x2">X of Point2</param>
-		/// <param name="y2">Y of Point2</param>
-		/// <param name="z2">Z of Point2</param>
-		/// <param name="zfactor">Factor for Z distance use lower 0..1 to lower Z influence</param>
-		/// <returns>The distance</returns>
-		[Obsolete( "Use Point3D.GetDistance" )]
-		public static int GetDistance( int x1, int y1, int z1, int x2, int y2, int z2, double zfactor )
-		{
-			long xdiff = (long)x1 - x2;
-			long ydiff = (long)y1 - y2;
-
-			long zdiff = (long)( ( z1 - z2 ) * zfactor );
-			return (int)Math.Sqrt( xdiff * xdiff + ydiff * ydiff + zdiff * zdiff );
-		}
-
-		/// <summary>
-		/// Gets the distance of an Object to an arbitary point
-		/// </summary>
-		/// <param name="obj">GameObject used as Point1</param>
-		/// <param name="x">X of Point2</param>
-		/// <param name="y">Y of Point2</param>
-		/// <param name="z">Z of Point2</param>
-		/// <returns>The distance</returns>
-		[Obsolete( "Use Point3D.GetDistance" )]
-		public static int GetDistance( GameObject obj, int x, int y, int z )
-		{
-			return GetDistance( obj.X, obj.Y, obj.Z, x, y, z );
-		}
-		#endregion get distance
-
-		#region check distance
-		[Obsolete( "Use Point3D.IsWithinRadius" )]
-		public static bool CheckDistance(int x1, int y1, int z1, int x2, int y2, int z2, int radius)
-		{
-			return CheckSquareDistance(x1, y1, z1, x2, y2, z2, radius * radius);
-		}
-		[Obsolete( "Use Point3D.IsWithinRadius" )]
-		public static bool CheckDistance( IPoint3D obj, IPoint3D obj2, int radius )
-		{
-			return CheckDistance(obj.X, obj.Y, obj.Z, obj2.X, obj2.Y, obj2.Z, radius);
-		}
-		[Obsolete( "Use Point3D.IsWithinRadius" )]
-		public static bool CheckDistance( GameObject obj, int x2, int y2, int z2, int radius )
-		{
-			return CheckDistance(obj.X, obj.Y, obj.Z, x2, y2, z2, radius);
-		}
-		[Obsolete( "Use Point3D.IsWithinRadius" )]
-		public static bool CheckDistance( GameObject obj, GameObject obj2, int radius )
-		{
-			if (obj == null || obj2 == null)
-				return false;
-			if (obj.CurrentRegion != obj2.CurrentRegion)
-				return false;
-			return CheckDistance(obj.X, obj.Y, obj.Z, obj2.X, obj2.Y, obj2.Z, radius);
-		}
-		#endregion
-		#region check square distance
-		[Obsolete( "Use Point3D.IsWithinRadius" )]
-		private static bool CheckSquareDistance( int x1, int y1, int z1, int x2, int y2, int z2, int squareRadius )
-		{
-			long xdiff = (long)x1 - x2;
-			long ydiff = (long)y1 - y2;
-			long zdiff = (long)z1 - z2;
-			return (xdiff * xdiff + ydiff * ydiff + zdiff * zdiff <= squareRadius);
-		}
-		[Obsolete( "Use Point3D.IsWithinRadius" )]
-		private static bool CheckSquareDistance( IPoint3D obj, IPoint3D obj2, int squareRadius )
-		{
-			return CheckSquareDistance(obj.X, obj.Y, obj.Z, obj2.X, obj2.Y, obj2.Z, squareRadius);
-		}
-		[Obsolete( "Use Point3D.IsWithinRadius" )]
-		private static bool CheckSquareDistance( GameObject obj, int x2, int y2, int z2, int squareRadius )
-		{
-			return CheckSquareDistance(obj.X, obj.Y, obj.Z, x2, y2, z2, squareRadius);
-		}
-		[Obsolete( "Use Point3D.IsWithinRadius" )]
-		private static bool CheckSquareDistance( GameObject obj, GameObject obj2, int squareRadius )
-		{
-			if (obj.CurrentRegion != obj2.CurrentRegion)
-				return false;
-			return CheckSquareDistance(obj.X, obj.Y, obj.Z, obj2.X, obj2.Y, obj2.Z, squareRadius);
-		}
-		#endregion
-
-		/// <summary>
-		/// Returns the number of playing Clients inside a realm
-		/// </summary>
-		/// <param name="realmID">ID of Realm (1=Alb, 2=Mid, 3=Hib)</param>
-		/// <returns>Client count of that realm</returns>
-		public static int GetClientsOfRealmCount(eRealm realm)
-		{
-			int count = 0;
-			lock (m_clients.SyncRoot)
-			{
-				foreach (GameClient client in m_clients)
-				{
-					if (client != null)
-					{
-						if (client.IsPlaying
-						    && client.Player != null
-						    && client.Player.ObjectState == GameObject.eObjectState.Active
-						    && client.Player.Realm == realm)
-							count++;
-					}
-				}
-			}
-			return count;
 		}
 
 		/// <summary>
@@ -1653,22 +1309,6 @@ namespace DOL.GS
 		}
 
 		/// <summary>
-		/// Find a GameClient by the Player's name from a specific region
-		/// </summary>
-		/// <param name="playerName">Name to search</param>
-		/// <param name="regionID">Region ID of region to search through</param>
-		/// <param name="exactMatch">true if the Name must match exactly</param>
-		/// <param name="activeRequired"></param>
-		/// <returns>The first found GameClient or null</returns>
-		public static GameClient GetClientByPlayerNameFromRegion(string playerName, ushort regionID, bool exactMatch, bool activeRequired)
-		{
-			GameClient client = GetClientByPlayerName(playerName, exactMatch, activeRequired);
-			if (client == null || client.Player.CurrentRegionID != regionID)
-				return null;
-			return client;
-		}
-
-		/// <summary>
 		/// Gets a copy of all playing clients
 		/// </summary>
 		/// <returns>ArrayList of playing GameClients</returns>
@@ -1724,24 +1364,6 @@ namespace DOL.GS
 		}
 
 		/// <summary>
-		/// Gets a count of ALL clients no matter at what state they are
-		/// </summary>
-		/// <returns>ArrayList of GameClients</returns>
-		public static int GetAllClientsCount()
-		{
-			int count = 0;
-			lock (m_clients.SyncRoot)
-			{
-				foreach (GameClient client in m_clients)
-				{
-					if (client != null)
-						count++;
-				}
-			}
-			return count;
-		}
-
-		/// <summary>
 		/// Fetch an Object from a specific Region by it's ID
 		/// </summary>
 		/// <param name="regionID">Region ID of Region to search through</param>
@@ -1753,21 +1375,6 @@ namespace DOL.GS
 			if (reg == null)
 				return null;
 			return reg.GetObject(oID);
-		}
-
-		/// <summary>
-		/// Fetch an Object of specific type from a specific Region
-		/// </summary>
-		/// <param name="regionID">Region ID of Regin to search through</param>
-		/// <param name="oID">Object ID to search</param>
-		/// <param name="type">Type of Object to search</param>
-		/// <returns>GameObject of specific type or null if not found</returns>
-		public static GameObject GetObjectTypeByIDFromRegion(ushort regionID, ushort oID, Type type)
-		{
-			GameObject obj = GetObjectByIDFromRegion(regionID, oID);
-			if (obj == null || !type.IsInstanceOfType(obj))
-				return null;
-			return obj;
 		}
 
 		/// <summary>
@@ -1864,26 +1471,6 @@ namespace DOL.GS
 		}
 
 		/// <summary>
-		/// Returns an IEnumerator of GameItems that are close to a certain
-		/// spot in the region
-		/// </summary>
-		/// <param name="regionid">Region to search</param>
-		/// <param name="x">X inside region</param>
-		/// <param name="y">Y inside region</param>
-		/// <param name="z">Z inside region</param>
-		/// <param name="radiusToCheck">Radius to sarch for GameItems</param>
-		/// <param name="withDistance">Wether or not to return the objects with distance</param>
-		/// <returns>IEnumerator that can be used to go through all items</returns>
-		public static IEnumerable GetItemsCloseToSpot(ushort regionid, int x, int y, int z, ushort radiusToCheck, bool withDistance)
-		{
-			Region reg = GetRegion(regionid);
-			if (reg == null)
-				return new Region.EmptyEnumerator();
-
-			return reg.GetItemsInRadius(x, y, z, radiusToCheck, withDistance);
-		}
-
-		/// <summary>
 		/// Saves all players into the database.
 		/// </summary>
 		/// <returns>The count of players saved</returns>
@@ -1919,20 +1506,10 @@ namespace DOL.GS
 		/// </summary>
 		private static Dictionary<ushort, RegionData> m_regionData;
 
-		public static IDictionary<ushort, RegionData> RegionData
-		{
-			get { return m_regionData; }
-		}
-
 		/// <summary>
 		/// Stores the zone data parsed from the zones file by RegionID.
 		/// </summary>
 		private static Dictionary<ushort, List<ZoneData>> m_zonesData;
-
-		public static Dictionary<ushort, List<ZoneData>> ZonesData
-		{
-			get { return m_zonesData; }
-		}
 
 
 		/// <summary>
@@ -2126,8 +1703,6 @@ namespace DOL.GS
 			//Destroy the region once and for all.
 			instance = null;
 		}
-
-
 		#endregion
 	}
 }

--- a/GameServerScripts/GameServerScripts.csproj
+++ b/GameServerScripts/GameServerScripts.csproj
@@ -149,6 +149,9 @@
     <Compile Include="globals.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="quests\Albion\GreetingsArmsman.cs" />
+    <Compile Include="quests\Albion\GreetingsPaladin.cs" />
+    <Compile Include="quests\Hibernia\BonesToBlades.cs" />
     <Compile Include="web\OnlineStatusUpdate.cs" />
     <Compile Include="web\WebUIGenerator.cs">
       <SubType>Code</SubType>
@@ -278,6 +281,9 @@
   <ItemGroup>
     <None Include="quests\Albion\BaseFrederickPathPoints.xml" />
     <None Include="quests\Hibernia\BaseAddrirPathPoints.xml" />
+    <None Include="quests\Hibernia\BasicsOfCombat.cs.rename.to.enable" />
+    <None Include="quests\Hibernia\MovementAndInteraction.cs.rename.to.enable" />
+    <None Include="quests\Midgard\MovementAndInteraction.cs.rename.to.enable" />
     <None Include="web\OnlineStatusUpdateServerFiles\serverinfo.php" />
     <None Include="web\OnlineStatusUpdateServerFiles\showplayers.php" />
   </ItemGroup>

--- a/GameServerScripts/GameServerScripts.csproj.user
+++ b/GameServerScripts/GameServerScripts.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectView>ShowAllFiles</ProjectView>
+  </PropertyGroup>
+</Project>

--- a/GameServerScripts/behaviour/examples/TestBehaviour.cs
+++ b/GameServerScripts/behaviour/examples/TestBehaviour.cs
@@ -32,8 +32,8 @@ namespace DOL.GS.Behaviour.Examples
 
             #region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Sir Quait", eRealm.Albion);
-            npcs = WorldMgr.GetNPCsByName("Sir Quait", (eRealm)1);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Sir Quait", eRealm.Albion);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>("Sir Quait", (eRealm)1);
             GameNPC SirQuait = null;
             if (npcs.Length == 0)
             {

--- a/GameServerScripts/quests/Albion/AFewRepairs.cs
+++ b/GameServerScripts/quests/Albion/AFewRepairs.cs
@@ -150,7 +150,7 @@ namespace DOL.GS.Quests.Albion
 
             #region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Brice Yarley", eRealm.Albion);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Brice Yarley", eRealm.Albion);
             if (npcs.Length == 0)
             {
                 briceYarley = new GameNPC();
@@ -180,7 +180,7 @@ namespace DOL.GS.Quests.Albion
             else
                 briceYarley = npcs[0];
 
-            npcs = WorldMgr.GetNPCsByName("Patrick Yarley", eRealm.Albion);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>("Patrick Yarley", eRealm.Albion);
             if (npcs.Length == 0)
             {
                 patrickYarley = new GameNPC();

--- a/GameServerScripts/quests/Albion/AMessageToTheManes.cs
+++ b/GameServerScripts/quests/Albion/AMessageToTheManes.cs
@@ -137,7 +137,7 @@ namespace DOL.GS.Quests.Albion
 
             #region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Sir Jerem", eRealm.Albion);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Sir Jerem", eRealm.Albion);
 
             /* Whops, if the npcs array length is 0 then no Sir Quait exists in
                 * this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/ANewHeroesWelcome.cs
+++ b/GameServerScripts/quests/Albion/ANewHeroesWelcome.cs
@@ -140,7 +140,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "Alb.ANewHeroesWelcome.ScriptLoaded.Text1"), eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "Alb.ANewHeroesWelcome.ScriptLoaded.Text1"), eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 			 * this users Mob Database, so we simply create one ;-)
@@ -187,7 +187,7 @@ namespace DOL.GS.Quests.Albion
 				MasterClaistan = npcs[0];
 
 			//Pompin The Crier
-			npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "Alb.ANewHeroesWelcome.ScriptLoaded.Text2"), eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "Alb.ANewHeroesWelcome.ScriptLoaded.Text2"), eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				PompinTheCrier = new GameNPC();

--- a/GameServerScripts/quests/Albion/AfterTheAccident.cs
+++ b/GameServerScripts/quests/Albion/AfterTheAccident.cs
@@ -200,7 +200,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Sir Prescott", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Sir Prescott", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 			 * this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/AgainstTheGrain.cs
+++ b/GameServerScripts/quests/Albion/AgainstTheGrain.cs
@@ -128,7 +128,7 @@ namespace DOL.GS.Quests.Albion
 			
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Laridia the Minstrel", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Laridia the Minstrel", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)
@@ -176,7 +176,7 @@ namespace DOL.GS.Quests.Albion
 				laridiaTheMinstrel = npcs[0];
 
 			
-			npcs = WorldMgr.GetNPCsByName("Farmer Asma", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Farmer Asma", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				farmerAsma = new GameNPC();

--- a/GameServerScripts/quests/Albion/Aiding_Guard_Alakyrr.cs
+++ b/GameServerScripts/quests/Albion/Aiding_Guard_Alakyrr.cs
@@ -89,7 +89,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Guard Alakyrr", eRealm.None);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Guard Alakyrr", eRealm.None);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Albion/AndrewsSkins.cs
+++ b/GameServerScripts/quests/Albion/AndrewsSkins.cs
@@ -136,7 +136,7 @@ namespace DOL.GS.Quests.Albion
 	
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Andrew Wyatt", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Andrew Wyatt", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)
@@ -181,7 +181,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				andrewWyatt = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Geor Nadren", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Geor Nadren", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -220,7 +220,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				georNadren = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Ver Nuren", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Ver Nuren", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Albion/ArgussArrows.cs
+++ b/GameServerScripts/quests/Albion/ArgussArrows.cs
@@ -149,7 +149,7 @@ namespace DOL.GS.Quests.Albion
 
             #region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Argus Bowman", eRealm.Albion);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Argus Bowman", eRealm.Albion);
 
             /* Whops, if the npcs array length is 0 then no Sir Quait exists in
                 * this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/ArleighsAssistant.cs
+++ b/GameServerScripts/quests/Albion/ArleighsAssistant.cs
@@ -147,7 +147,7 @@ namespace DOL.GS.Quests.Albion
 
             #region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Arleigh Penn", eRealm.Albion);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Arleigh Penn", eRealm.Albion);
 
             /* Whops, if the npcs array length is 0 then no Sir Quait exists in
                 * this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/ArrowsForYettaFletcher.cs
+++ b/GameServerScripts/quests/Albion/ArrowsForYettaFletcher.cs
@@ -130,7 +130,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Yetta Fletcher", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Yetta Fletcher", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/BaseFrederickQuest.cs
+++ b/GameServerScripts/quests/Albion/BaseFrederickQuest.cs
@@ -150,7 +150,7 @@ namespace DOL.GS.Quests.Albion
 
 		public static GameNPC GetMasterFrederick()
 		{
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Master Frederick", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Master Frederick", eRealm.Albion);
 
 			GameNPC masterFrederick = null;
 

--- a/GameServerScripts/quests/Albion/BeginningOfWar.cs
+++ b/GameServerScripts/quests/Albion/BeginningOfWar.cs
@@ -170,7 +170,7 @@ namespace DOL.GS.Quests.Albion
 
 			masterFrederick = GetMasterFrederick();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Master Dunwyn", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Master Dunwyn", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -209,7 +209,7 @@ namespace DOL.GS.Quests.Albion
 				dunwyn = npcs[0];
 
 
-			npcs = WorldMgr.GetNPCsByName("Princess Obera", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Princess Obera", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Albion/BoarStew.cs
+++ b/GameServerScripts/quests/Albion/BoarStew.cs
@@ -141,7 +141,7 @@ namespace DOL.GS.Quests.Albion
 
             #region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Master Gerol", eRealm.Albion);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Master Gerol", eRealm.Albion);
             if (npcs.Length == 0)
             {
                 masterGerol = new GameNPC();

--- a/GameServerScripts/quests/Albion/BoulderlingBalm.cs
+++ b/GameServerScripts/quests/Albion/BoulderlingBalm.cs
@@ -143,7 +143,7 @@ namespace DOL.GS.Quests.Albion
 
             #region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Brother Maynard", eRealm.Albion);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Brother Maynard", eRealm.Albion);
 
             /* Whops, if the npcs array length is 0 then no Sir Quait exists in
                 * this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/BreakingTheBandits.cs
+++ b/GameServerScripts/quests/Albion/BreakingTheBandits.cs
@@ -141,7 +141,7 @@ namespace DOL.GS.Quests.Albion
 
             #region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Atheleys Sy'Lian", eRealm.Albion);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Atheleys Sy'Lian", eRealm.Albion);
 
             /* Whops, if the npcs array length is 0 then no Sir Quait exists in
                 * this users Mob Database, so we simply create one ;-)
@@ -177,7 +177,7 @@ namespace DOL.GS.Quests.Albion
             else
                 atheleys = npcs[0];
 
-            npcs = WorldMgr.GetNPCsByName("Mostram", eRealm.None);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>("Mostram", eRealm.None);
 
 
             if (npcs.Length == 0)

--- a/GameServerScripts/quests/Albion/BuildingABetterBow.cs
+++ b/GameServerScripts/quests/Albion/BuildingABetterBow.cs
@@ -131,7 +131,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Elvar Ironhand", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Elvar Ironhand", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/Cellar_Infestation.cs
+++ b/GameServerScripts/quests/Albion/Cellar_Infestation.cs
@@ -108,7 +108,7 @@ using DOL.AI.Brain;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-			npcs = WorldMgr.GetNPCsByName("Mistress Laws",(eRealm) 1);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Mistress Laws",(eRealm) 1);
 			if (npcs.Length == 0)
 			{
 				if (!WorldMgr.GetRegion(51).IsDisabled)
@@ -153,7 +153,7 @@ using DOL.AI.Brain;
 				MistressLaws = npcs[0];
 			}
 		
-			npcs = WorldMgr.GetNPCsByName("Ylaine Barrett",(eRealm) 1);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Ylaine Barrett",(eRealm) 1);
 			if (npcs.Length == 0)
 			{
 				if (!WorldMgr.GetRegion(51).IsDisabled)

--- a/GameServerScripts/quests/Albion/CemmethsOrders.cs
+++ b/GameServerScripts/quests/Albion/CemmethsOrders.cs
@@ -248,7 +248,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Cemmeth Budgwold", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Cemmeth Budgwold", eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Albion/ChildsPlay.cs
+++ b/GameServerScripts/quests/Albion/ChildsPlay.cs
@@ -111,7 +111,7 @@ namespace DOL.GS.Quests.Albion
 			#region defineNPCs
 			GameNPC[] npcs;
 
-			npcs = WorldMgr.GetNPCsByName("Charles", (eRealm)1);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Charles", (eRealm)1);
 			if (npcs.Length == 0)
 			{
 				Charles = new DOL.GS.GameNPC();

--- a/GameServerScripts/quests/Albion/CityOfCamelot.cs
+++ b/GameServerScripts/quests/Albion/CityOfCamelot.cs
@@ -156,7 +156,7 @@ namespace DOL.GS.Quests.Albion
 
 			masterFrederick = GetMasterFrederick();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lord Urqhart", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Lord Urqhart", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -185,7 +185,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				lordUrqhart = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Bombard", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Bombard", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Albion/ClericMulgrut.cs
+++ b/GameServerScripts/quests/Albion/ClericMulgrut.cs
@@ -130,7 +130,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Hugh Gallen", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Hugh Gallen", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/Collection.cs
+++ b/GameServerScripts/quests/Albion/Collection.cs
@@ -150,7 +150,7 @@ namespace DOL.GS.Quests.Albion
 			GameNPC[] npcs = null;
 			for (int i = 0; i < general.Length; i++)
 			{
-				npcs = WorldMgr.GetNPCsByName(generalNames[i], eRealm.None);
+				npcs = WorldMgr.GetObjectsByName<GameNPC>(generalNames[i], eRealm.None);
 				if (npcs.Length > 0)
 					general[i] = npcs[0] as GameNPC;
 				else

--- a/GameServerScripts/quests/Albion/Culmination.cs
+++ b/GameServerScripts/quests/Albion/Culmination.cs
@@ -152,7 +152,7 @@ namespace DOL.GS.Quests.Albion
 
 			masterFrederick = GetMasterFrederick();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Queen Tatiana", eRealm.None);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Queen Tatiana", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Albion/Disenchanted.cs
+++ b/GameServerScripts/quests/Albion/Disenchanted.cs
@@ -150,7 +150,7 @@ namespace DOL.GS.Quests.Albion
 
             #region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Palune", eRealm.Albion);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Palune", eRealm.Albion);
             if (npcs.Length == 0)
             {
                 palune = new GameNPC();
@@ -180,7 +180,7 @@ namespace DOL.GS.Quests.Albion
             else
                 palune = npcs[0];
 
-            npcs = WorldMgr.GetNPCsByName("Guard Cynon", eRealm.Albion);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>("Guard Cynon", eRealm.Albion);
             if (npcs.Length == 0)
             {
                 guardCynon = new GameNPC();

--- a/GameServerScripts/quests/Albion/DredgeUpAPledge.cs
+++ b/GameServerScripts/quests/Albion/DredgeUpAPledge.cs
@@ -93,7 +93,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Sir Dorian", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Sir Dorian", eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Albion/Frontiers.cs
+++ b/GameServerScripts/quests/Albion/Frontiers.cs
@@ -158,7 +158,7 @@ namespace DOL.GS.Quests.Albion
 			masterFrederick = GetMasterFrederick();
 
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Master Visur", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Master Visur", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -198,7 +198,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				masterVisur = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Scryer Alice", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Scryer Alice", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -256,7 +256,7 @@ namespace DOL.GS.Quests.Albion
 			dragonflyTicket = CreateTicketTo("Castle Sauvage", "hs_src_castlesauvage");
 			horseTicket = CreateTicketTo("Camelot Hills", "hs_src_camelothills");
 
-			npcs = (GameNPC[]) WorldMgr.GetObjectsByName("Dragonfly Handler Colm", eRealm.Albion, typeof (GameStableMaster));
+			npcs = WorldMgr.GetObjectsByName<GameStableMaster>("Dragonfly Handler Colm", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -354,7 +354,7 @@ namespace DOL.GS.Quests.Albion
 				dragonfly.AddToWorld();
 			}
 
-			npcs = (GameNPC[]) WorldMgr.GetObjectsByName("Uliam", eRealm.Albion, typeof (GameStableMaster));
+			npcs = WorldMgr.GetObjectsByName<GameStableMaster>("Uliam", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Albion/GodelevasNeed.cs
+++ b/GameServerScripts/quests/Albion/GodelevasNeed.cs
@@ -138,7 +138,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Godeleva Dowden", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Godeleva Dowden", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/GreenerPastures.cs
+++ b/GameServerScripts/quests/Albion/GreenerPastures.cs
@@ -139,7 +139,7 @@ namespace DOL.GS.Quests.Albion
 			
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Farmer Asma", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Farmer Asma", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				farmerAsma = new GameNPC();

--- a/GameServerScripts/quests/Albion/GreetingsArmsman.cs
+++ b/GameServerScripts/quests/Albion/GreetingsArmsman.cs
@@ -271,7 +271,7 @@ namespace DOL.GS.Quests.Albion
 			if (log.IsInfoEnabled)
 				log.Info("Quest \"" + questTitle + "\" initializing ...");
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Captain Kinzee", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Captain Kinzee", eRealm.Albion);
 
             if (npcs == null || npcs.Length == 0)
             {

--- a/GameServerScripts/quests/Albion/GreetingsPaladin.cs
+++ b/GameServerScripts/quests/Albion/GreetingsPaladin.cs
@@ -271,7 +271,7 @@ namespace DOL.GS.Quests.Albion
 			if (log.IsInfoEnabled)
 				log.Info("Quest \"" + questTitle + "\" initializing ...");
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Sir Strain", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Sir Strain", eRealm.Albion);
 
             if (npcs == null || npcs.Length == 0)
             {

--- a/GameServerScripts/quests/Albion/HalfOgreAllMan.cs
+++ b/GameServerScripts/quests/Albion/HalfOgreAllMan.cs
@@ -154,7 +154,7 @@ namespace DOL.GS.Quests.Albion
 			
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Madissair", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Madissair", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				madissair = new GameNPC();
@@ -195,7 +195,7 @@ namespace DOL.GS.Quests.Albion
 				madissair = npcs[0];
 
 
-			npcs = WorldMgr.GetNPCsByName("Eileen Morton", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Eileen Morton", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				eileenMorton = new GameNPC();
@@ -235,7 +235,7 @@ namespace DOL.GS.Quests.Albion
 				eileenMorton = npcs[0];
 
 
-			npcs = WorldMgr.GetNPCsByName("Scribe Veral", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Scribe Veral", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				scribeVeral = new GameNPC();
@@ -273,7 +273,7 @@ namespace DOL.GS.Quests.Albion
 				scribeVeral = npcs[0];
 
 
-			npcs = WorldMgr.GetNPCsByName("Serawen", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Serawen", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				serawen = new GameNPC();

--- a/GameServerScripts/quests/Albion/HeartOfSephucoth.cs
+++ b/GameServerScripts/quests/Albion/HeartOfSephucoth.cs
@@ -136,7 +136,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Eowyln Astos", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Eowyln Astos", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/HuntForArachneida.cs
+++ b/GameServerScripts/quests/Albion/HuntForArachneida.cs
@@ -147,7 +147,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Kealan", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Kealan", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no Sir Quait exists in
 				* this users Mob Database, so we simply create one ;-)
@@ -186,7 +186,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				kealan = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Arachneida", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Arachneida", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				arachneida = new GameNPC();

--- a/GameServerScripts/quests/Albion/HuntForSlith.cs
+++ b/GameServerScripts/quests/Albion/HuntForSlith.cs
@@ -130,7 +130,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Commander Burcrif", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Commander Burcrif", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/ImportantDelivery.cs
+++ b/GameServerScripts/quests/Albion/ImportantDelivery.cs
@@ -143,7 +143,7 @@ namespace DOL.GS.Quests.Albion
 
 			masterFrederick = GetMasterFrederick();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Apprentice Dunan", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Apprentice Dunan", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				dunan = new GameNPC();
@@ -171,7 +171,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				dunan = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Bombard", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Bombard", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				bombard = new GameStableMaster();
@@ -199,7 +199,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				bombard = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Vuloch", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Vuloch", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				vuloch = new GameStableMaster();
@@ -228,7 +228,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				vuloch = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Yaren", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Yaren", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				yaren = new GameStableMaster();

--- a/GameServerScripts/quests/Albion/IreFairyIre.cs
+++ b/GameServerScripts/quests/Albion/IreFairyIre.cs
@@ -148,7 +148,7 @@ namespace DOL.GS.Quests.Albion
 
 			masterFrederick = GetMasterFrederick();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Nob the Stableboy", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Nob the Stableboy", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				nob = new GameNPC();
@@ -178,7 +178,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				nob = npcs[0];
 
-			npcs = (GameNPC[]) WorldMgr.GetObjectsByName("Dragonfly Handler Colm", eRealm.Albion, typeof (GameStableMaster));
+			npcs = WorldMgr.GetObjectsByName<GameStableMaster>("Dragonfly Handler Colm", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				colm = new GameStableMaster();
@@ -227,7 +227,7 @@ namespace DOL.GS.Quests.Albion
 				colm = npcs[0] as GameStableMaster;
 			}
 
-			npcs = WorldMgr.GetNPCsByName("Haruld", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Haruld", eRealm.Albion);
 			if (npcs.Length == 0 || !(npcs[0] is GameStableMaster))
 			{
 				haruld = new GameStableMaster();
@@ -266,7 +266,7 @@ namespace DOL.GS.Quests.Albion
 				haruld = npcs[0] as GameStableMaster;
 			}
 
-			npcs = WorldMgr.GetNPCsByName("Fairy Dragonfly Handler", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Fairy Dragonfly Handler", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				fairyDragonflyHandler = new GameNPC();

--- a/GameServerScripts/quests/Albion/LawrencesOil.cs
+++ b/GameServerScripts/quests/Albion/LawrencesOil.cs
@@ -131,7 +131,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Brother Lawrence", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Brother Lawrence", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/MarlinsSalesPitch.cs
+++ b/GameServerScripts/quests/Albion/MarlinsSalesPitch.cs
@@ -142,7 +142,7 @@ namespace DOL.GS.Quests.Albion
 
             #region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Marlin Thuler", eRealm.Albion);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Marlin Thuler", eRealm.Albion);
 
             /* Whops, if the npcs array length is 0 then no Sir Quait exists in
                 * this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/MovementAndInteraction.cs
+++ b/GameServerScripts/quests/Albion/MovementAndInteraction.cs
@@ -104,7 +104,7 @@ namespace DOL.GS.Quests.Albion {
 				log.Info("Quest \"" + questTitle + "\" initializing ...");
 
 			#region defineNPCS
-			GameNPC[] npcs = WorldMgr.GetNPCsByName(questGiverName, eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>(questGiverName, eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{
@@ -141,7 +141,7 @@ namespace DOL.GS.Quests.Albion {
 			else
 				questGiver = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName(questTargetName, eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>(questTargetName, eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Albion/NoHopeForTheHopeful.cs
+++ b/GameServerScripts/quests/Albion/NoHopeForTheHopeful.cs
@@ -187,7 +187,7 @@ namespace DOL.GS.Quests.Albion
 			if (log.IsInfoEnabled)
 				log.Info("Quest \"" + questTitle + "\" initializing ...");
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Sir Dorian", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Sir Dorian", eRealm.Albion);
 			if (npcs == null || npcs.Length == 0)
 				return;
 

--- a/GameServerScripts/quests/Albion/RecruitingNothingButTrouble.cs
+++ b/GameServerScripts/quests/Albion/RecruitingNothingButTrouble.cs
@@ -299,7 +299,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Rheda", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Rheda", eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Albion/RevengeTheOtherWhiteMeat.cs
+++ b/GameServerScripts/quests/Albion/RevengeTheOtherWhiteMeat.cs
@@ -129,7 +129,7 @@ namespace DOL.GS.Quests.Albion
 			
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Farmer Asma", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Farmer Asma", eRealm.Albion);
 			
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)

--- a/GameServerScripts/quests/Albion/ShakenSquire.cs
+++ b/GameServerScripts/quests/Albion/ShakenSquire.cs
@@ -131,7 +131,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Sir Jerem", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Sir Jerem", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)
@@ -180,7 +180,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				sirJerem = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Squire Galune", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Squire Galune", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				squireGalune = new GameNPC();

--- a/GameServerScripts/quests/Albion/ToReachTheBreach.cs
+++ b/GameServerScripts/quests/Albion/ToReachTheBreach.cs
@@ -189,7 +189,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lady Grynoch", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Lady Grynoch", eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Albion/TombWithAView.cs
+++ b/GameServerScripts/quests/Albion/TombWithAView.cs
@@ -244,7 +244,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lady Grynoch", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Lady Grynoch", eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Albion/TraitorInCotswold.cs
+++ b/GameServerScripts/quests/Albion/TraitorInCotswold.cs
@@ -141,7 +141,7 @@ namespace DOL.GS.Quests.Albion
 
 			masterFrederick = GetMasterFrederick();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lady Felin", eRealm.None);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Lady Felin", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				//if (Log.IsWarnEnabled) Log.Warn("Could not find Lady Felin, creating her ...");

--- a/GameServerScripts/quests/Albion/TreviansBestFriend.cs
+++ b/GameServerScripts/quests/Albion/TreviansBestFriend.cs
@@ -154,7 +154,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Trevian", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Trevian", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)
@@ -201,7 +201,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				trevian = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Trevian's Puppy", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Trevian's Puppy", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -230,7 +230,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				puppy = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Guard Brydus", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Guard Brydus", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -270,7 +270,7 @@ namespace DOL.GS.Quests.Albion
 
 
 			// mob db check
-			GameObject[] mobs = WorldMgr.GetObjectsByNameFromRegion(banditAbductorLeaderName, 1, eRealm.None, typeof (GameNPC));
+			GameObject[] mobs = WorldMgr.GetObjectsByNameFromRegion<GameNPC>(banditAbductorLeaderName, 1, eRealm.None);
 			if (mobs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -311,7 +311,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				banditAbductorLeader = mobs[0] as GameNPC;
 
-			mobs = WorldMgr.GetObjectsByNameFromRegion(banditAbductorName, 1, eRealm.None, typeof (GameNPC));
+			mobs = WorldMgr.GetObjectsByNameFromRegion<GameNPC>(banditAbductorName, 1, eRealm.None);
 			if (mobs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Albion/WhenBloodSpeaks.cs
+++ b/GameServerScripts/quests/Albion/WhenBloodSpeaks.cs
@@ -254,7 +254,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Alb.WhenBloodSpeaks.ScriptLoaded.Text1"), eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Alb.WhenBloodSpeaks.ScriptLoaded.Text1"), eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Albion/WhenGoodBrowniesGoBad.cs
+++ b/GameServerScripts/quests/Albion/WhenGoodBrowniesGoBad.cs
@@ -197,7 +197,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "Alb.WhenGoodBrowniesGoBad.ScriptLoaded.Text1"), eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "Alb.WhenGoodBrowniesGoBad.ScriptLoaded.Text1"), eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Albion/WolfPeltCloak.cs
+++ b/GameServerScripts/quests/Albion/WolfPeltCloak.cs
@@ -149,7 +149,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCs
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Steward Willie", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Steward Willie", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no Sir Quait exists in
 				* this users Mob Database, so we simply create one ;-)
@@ -187,7 +187,7 @@ namespace DOL.GS.Quests.Albion
 
 			/* Now we do the same for the Lynnet.
 			*/
-			npcs = WorldMgr.GetNPCsByName("Seamstress Lynnet", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Seamstress Lynnet", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				lynnet = new GameNPC();
@@ -222,7 +222,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				lynnet = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Brother Don", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Brother Don", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				don = new GameNPC();

--- a/GameServerScripts/quests/Albion/YdeniasCrush.cs
+++ b/GameServerScripts/quests/Albion/YdeniasCrush.cs
@@ -134,7 +134,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Ydenia Philpott", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Ydenia Philpott", eRealm.Albion);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)
@@ -182,7 +182,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				ydeniaPhilpott = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Elvar Tambor", eRealm.Albion);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Elvar Tambor", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Albion/epic/Academy50.cs
+++ b/GameServerScripts/quests/Albion/epic/Academy50.cs
@@ -105,7 +105,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCs
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Master Ferowl", eRealm.Albion);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Master Ferowl", eRealm.Albion);
 			if (npcs.Length == 0)
 			{
 				Ferowl = new GameNPC();
@@ -131,7 +131,7 @@ namespace DOL.GS.Quests.Albion
 				Ferowl = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Morgana", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Morgana", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				Morgana = new GameNPC();
@@ -170,7 +170,7 @@ namespace DOL.GS.Quests.Albion
 			else
 				Morgana = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Bechard", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Bechard", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -196,7 +196,7 @@ namespace DOL.GS.Quests.Albion
 				Bechard = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Silcharde", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Silcharde", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Albion/epic/Church50.cs
+++ b/GameServerScripts/quests/Albion/epic/Church50.cs
@@ -94,7 +94,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCs
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Roben Fraomar", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Roben Fraomar", eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{
@@ -121,7 +121,7 @@ namespace DOL.GS.Quests.Albion
 				Roben = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Sister Blythe", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Sister Blythe", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Albion/epic/Defenders50.cs
+++ b/GameServerScripts/quests/Albion/epic/Defenders50.cs
@@ -95,7 +95,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region defineNPCs
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lidmann Halsey", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Lidmann Halsey", eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{
@@ -127,7 +127,7 @@ namespace DOL.GS.Quests.Albion
 				Lidmann = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Cailleach Uragaig", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Cailleach Uragaig", eRealm.None);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Albion/epic/Shadows50.cs
+++ b/GameServerScripts/quests/Albion/epic/Shadows50.cs
@@ -104,7 +104,7 @@ namespace DOL.GS.Quests.Albion
 
 			#region NPC Declarations
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lidmann Halsey", eRealm.Albion);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Lidmann Halsey", eRealm.Albion);
 
 			if (npcs.Length == 0)
 			{
@@ -133,7 +133,7 @@ namespace DOL.GS.Quests.Albion
 				Lidmann = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Cailleach Uragaig", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Cailleach Uragaig", eRealm.None);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Examples and  Tutorials/Classic quest/HelpSirQuait.cs
+++ b/GameServerScripts/quests/Examples and  Tutorials/Classic quest/HelpSirQuait.cs
@@ -108,7 +108,7 @@ using DOL.AI.Brain;
 	    #region defineNPCs
 	    GameNPC[] npcs;
 	
-		npcs = WorldMgr.GetNPCsByName("Sir Quait",(eRealm) 1);
+		npcs = WorldMgr.GetObjectsByName<GameNPC>("Sir Quait",(eRealm) 1);
 		if (npcs.Length == 0)
 		{			
 			SirQuait = new DOL.GS.GameNPC();
@@ -150,7 +150,7 @@ using DOL.AI.Brain;
 			SirQuait = npcs[0];
 		}
 	
-		npcs = WorldMgr.GetNPCsByName("Evil Thief of the Shadowclan",(eRealm) 0);
+		npcs = WorldMgr.GetObjectsByName<GameNPC>("Evil Thief of the Shadowclan",(eRealm) 0);
 		if (npcs.Length == 0)
 		{			
 			EvilThiefoftheShadowclan = new DOL.GS.GameNPC();

--- a/GameServerScripts/quests/Examples and  Tutorials/Search quest/WingsOfTheIsleHibernia.cs
+++ b/GameServerScripts/quests/Examples and  Tutorials/Search quest/WingsOfTheIsleHibernia.cs
@@ -292,7 +292,7 @@ namespace DOL.GS.Quests.Hibernia
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Baeth", eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Baeth", eRealm.Hibernia);
 
 			/*  If the npcs array length is 0 then no npc exists in
 				* this users Mob Database, so we simply create one ;-)
@@ -331,7 +331,7 @@ namespace DOL.GS.Quests.Hibernia
 				npcBaeth = npcs[0];
 			}
 
-			npcs = WorldMgr.GetNPCsByName("Jessica", eRealm.Hibernia);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Jessica", eRealm.Hibernia);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Hibernia/BaseAddrirQuest.cs
+++ b/GameServerScripts/quests/Hibernia/BaseAddrirQuest.cs
@@ -141,7 +141,7 @@ namespace DOL.GS.Quests.Hibernia
 
 		public static GameNPC GetAddrir()
 		{
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Addrir", eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Addrir", eRealm.Hibernia);
 
 			GameNPC addrir = null;
 

--- a/GameServerScripts/quests/Hibernia/BonesToBlades.cs
+++ b/GameServerScripts/quests/Hibernia/BonesToBlades.cs
@@ -116,7 +116,7 @@ namespace DOL.GS.Quests.Hibernia
 				log.Info("Quest \"" + questTitle + "\" initializing ...");
 
 			#region defineNPCS
-			GameNPC[] npcs = WorldMgr.GetNPCsByName(questGiverName, eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>(questGiverName, eRealm.Hibernia);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -153,7 +153,7 @@ namespace DOL.GS.Quests.Hibernia
 			else
 				questGiver = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName(questTargetName, eRealm.Hibernia);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>(questTargetName, eRealm.Hibernia);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Hibernia/ChildsPlay.cs
+++ b/GameServerScripts/quests/Hibernia/ChildsPlay.cs
@@ -111,7 +111,7 @@ namespace DOL.GS.Quests.Hibernia
             #region defineNPCs
             GameNPC[] npcs;
 
-            npcs = WorldMgr.GetNPCsByName("Charles", (eRealm)3);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>("Charles", (eRealm)3);
             if (npcs.Length == 0)
             {
                 Charles = new DOL.GS.GameNPC();

--- a/GameServerScripts/quests/Hibernia/CityOfTirnaNog.cs
+++ b/GameServerScripts/quests/Hibernia/CityOfTirnaNog.cs
@@ -161,7 +161,7 @@ namespace DOL.GS.Quests.Hibernia
 
 			addrir = GetAddrir();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Bhreagar Hylvian", eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Bhreagar Hylvian", eRealm.Hibernia);
 			if (npcs.Length == 0)
 			{
 				hylvian = new GameNPC();
@@ -190,7 +190,7 @@ namespace DOL.GS.Quests.Hibernia
 			else
 				hylvian = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Freagus", eRealm.Hibernia);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Freagus", eRealm.Hibernia);
 			if (npcs.Length == 0)
 			{
 				freagus = new GameStableMaster();
@@ -219,7 +219,7 @@ namespace DOL.GS.Quests.Hibernia
 			else
 				freagus = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Gweonry", eRealm.Hibernia);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Gweonry", eRealm.Hibernia);
 			if (npcs.Length == 0)
 			{
 				gweonry = new GameStableMaster();

--- a/GameServerScripts/quests/Hibernia/ImportantDelivery.cs
+++ b/GameServerScripts/quests/Hibernia/ImportantDelivery.cs
@@ -146,7 +146,7 @@ namespace DOL.GS.Quests.Hibernia
 
 			addrir = GetAddrir();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Aethic", eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Aethic", eRealm.Hibernia);
 			if (npcs.Length == 0)
 			{
 				aethic = new GameNPC();
@@ -174,7 +174,7 @@ namespace DOL.GS.Quests.Hibernia
 			else
 				aethic = npcs[0] as GameStableMaster;
 
-			npcs = WorldMgr.GetNPCsByName("Freagus", eRealm.Hibernia);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Freagus", eRealm.Hibernia);
 			if (npcs.Length == 0)
 			{
 				freagus = new GameStableMaster();
@@ -203,7 +203,7 @@ namespace DOL.GS.Quests.Hibernia
 			else
 				freagus = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Rumdor", eRealm.Hibernia);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Rumdor", eRealm.Hibernia);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -233,7 +233,7 @@ namespace DOL.GS.Quests.Hibernia
 			else
 				rumdor = npcs[0] as GameStableMaster;
 
-			GameObject[] objects = WorldMgr.GetObjectsByName("Truichon", eRealm.Hibernia,typeof(GameStableMaster));
+			npcs = WorldMgr.GetObjectsByName<GameStableMaster>("Truichon", eRealm.Hibernia);
             if (npcs.Length == 0)
             {
                 truichon = new GameStableMaster();

--- a/GameServerScripts/quests/Hibernia/MagicalBacklash.cs
+++ b/GameServerScripts/quests/Hibernia/MagicalBacklash.cs
@@ -297,7 +297,7 @@ namespace DOL.GS.Quests.Hibernia
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Josson", eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Josson", eRealm.Hibernia);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Hibernia/SearchForKnowledge.cs
+++ b/GameServerScripts/quests/Hibernia/SearchForKnowledge.cs
@@ -153,7 +153,7 @@ namespace DOL.GS.Quests.Hibernia
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Blercyn", eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Blercyn", eRealm.Hibernia);
 
 			/* Whops, if the npcs array length is 0 then no npc exists in
 			 * this users Mob Database, so we simply create one ;-)
@@ -196,7 +196,7 @@ namespace DOL.GS.Quests.Hibernia
 				Blercyn = npcs[0];
 
 			//Pompin The Crier
-			npcs = WorldMgr.GetNPCsByName("Epona", eRealm.Hibernia);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Epona", eRealm.Hibernia);
 			if (npcs.Length == 0)
 			{
 				Epona = new GameNPC();

--- a/GameServerScripts/quests/Hibernia/ToReachTheBreach.cs
+++ b/GameServerScripts/quests/Hibernia/ToReachTheBreach.cs
@@ -202,7 +202,7 @@ namespace DOL.GS.Quests.Hibernia
 
 			#region defineNPCS
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Richael", eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Richael", eRealm.Hibernia);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Hibernia/TraitorInMagMell.cs
+++ b/GameServerScripts/quests/Hibernia/TraitorInMagMell.cs
@@ -141,7 +141,7 @@ namespace DOL.GS.Quests.Hibernia
 
 			addrir = GetAddrir();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lady Legada", eRealm.None);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Lady Legada", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				//if (Log.IsWarnEnabled) Log.Warn("Could not find Lady Felin, creating her ...");

--- a/GameServerScripts/quests/Hibernia/epic/Essence50.cs
+++ b/GameServerScripts/quests/Hibernia/epic/Essence50.cs
@@ -112,7 +112,7 @@ namespace DOL.GS.Quests.Hibernia
 
 			#region NPC Declarations
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Brigit", eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Brigit", eRealm.Hibernia);
 
 			if (npcs.Length == 0)
 			{
@@ -141,7 +141,7 @@ namespace DOL.GS.Quests.Hibernia
 				Brigit = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Caithor", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Caithor", eRealm.None);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Hibernia/epic/Focus50.cs
+++ b/GameServerScripts/quests/Hibernia/epic/Focus50.cs
@@ -112,7 +112,7 @@ namespace DOL.GS.Quests.Hibernia
 
 			#region NPC Declarations
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Ainrebh", eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Ainrebh", eRealm.Hibernia);
 
 			if (npcs.Length == 0)
 			{
@@ -141,7 +141,7 @@ namespace DOL.GS.Quests.Hibernia
 				Ainrebh = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Green Maw", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Green Maw", eRealm.None);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Hibernia/epic/Harmony50.cs
+++ b/GameServerScripts/quests/Hibernia/epic/Harmony50.cs
@@ -112,7 +112,7 @@ namespace DOL.GS.Quests.Hibernia
 
 			#region NPC Declarations
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Revelin", eRealm.Hibernia);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Revelin", eRealm.Hibernia);
 
 			if (npcs.Length == 0)
 			{
@@ -142,7 +142,7 @@ namespace DOL.GS.Quests.Hibernia
 				Revelin = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Cailean", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Cailean", eRealm.None);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Midgard/A_Beary_Bad_Problem.cs
+++ b/GameServerScripts/quests/Midgard/A_Beary_Bad_Problem.cs
@@ -109,7 +109,7 @@ namespace DOL.GS.Quests.Midgard
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-            npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.ABearyBadProblem.NPCKreimhilde"),(eRealm) 2);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.ABearyBadProblem.NPCKreimhilde"),(eRealm) 2);
 			if (npcs.Length == 0)
 			{			
 				VikingKreimhilde = new DOL.GS.GameNPC();

--- a/GameServerScripts/quests/Midgard/Amoras_Aid.cs
+++ b/GameServerScripts/quests/Midgard/Amoras_Aid.cs
@@ -110,7 +110,7 @@ using DOL.AI.Brain;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-			npcs = WorldMgr.GetNPCsByName("Lycla",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Lycla",(eRealm) 2);
 			if (npcs.Length == 0)
 			{			
 				Lycla = new DOL.GS.GameNPC();
@@ -152,7 +152,7 @@ using DOL.AI.Brain;
 				Lycla = npcs[0];
 			}
 		
-			npcs = WorldMgr.GetNPCsByName("Amora",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Amora",(eRealm) 2);
 			if (npcs.Length == 0)
 			{			
 				Amora = new DOL.GS.GameNPC();
@@ -194,7 +194,7 @@ using DOL.AI.Brain;
 				Amora = npcs[0];
 			}
 		
-			npcs = WorldMgr.GetNPCsByName("Kari",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Kari",(eRealm) 2);
 			if (npcs.Length == 0)
 			{			
 				Kari = new GameHealer();

--- a/GameServerScripts/quests/Midgard/Bad_Food.cs
+++ b/GameServerScripts/quests/Midgard/Bad_Food.cs
@@ -108,7 +108,7 @@ using DOL.AI.Brain;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-			npcs = WorldMgr.GetNPCsByName("Pedra",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Pedra",(eRealm) 2);
 			if (npcs.Length == 0)
 			{			
 				Pedra = new DOL.GS.GameNPC();
@@ -150,7 +150,7 @@ using DOL.AI.Brain;
 				Pedra = npcs[0];
 			}
 		
-			npcs = WorldMgr.GetNPCsByName("Kedra",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Kedra",(eRealm) 2);
 			if (npcs.Length == 0)
 			{			
 				Kedra = new GameHealer();

--- a/GameServerScripts/quests/Midgard/BaseDalikorQuest.cs
+++ b/GameServerScripts/quests/Midgard/BaseDalikorQuest.cs
@@ -153,7 +153,7 @@ namespace DOL.GS.Quests.Midgard
 
 		public static GameNPC GetDalikor()
 		{
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Dalikor", eRealm.Midgard);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Dalikor", eRealm.Midgard);
 
 			GameNPC dalikor = null;
 

--- a/GameServerScripts/quests/Midgard/Bear Skins.cs
+++ b/GameServerScripts/quests/Midgard/Bear Skins.cs
@@ -106,7 +106,7 @@ using DOL.AI.Brain;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-			npcs = WorldMgr.GetNPCsByName("Helen",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Helen",(eRealm) 2);
 			if (npcs.Length == 0)
 			{			
 				Helen = new DOL.GS.GameNPC();

--- a/GameServerScripts/quests/Midgard/BeginningOfWar.cs
+++ b/GameServerScripts/quests/Midgard/BeginningOfWar.cs
@@ -169,7 +169,7 @@ namespace DOL.GS.Quests.Midgard
 
 			dalikor = GetDalikor();
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName("Master Briedi", eRealm.Midgard);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Master Briedi", eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				briedi = new GameNPC();
@@ -219,7 +219,7 @@ namespace DOL.GS.Quests.Midgard
 				briedi = npcs[0];
 
 
-			npcs = WorldMgr.GetNPCsByName("Princess Aiyr", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Princess Aiyr", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				princessAiyr = new GameNPC();

--- a/GameServerScripts/quests/Midgard/Childs_Play.cs
+++ b/GameServerScripts/quests/Midgard/Childs_Play.cs
@@ -111,7 +111,7 @@ namespace DOL.GS.Quests.Midgard
             #region defineNPCs
             GameNPC[] npcs;
 
-            npcs = WorldMgr.GetNPCsByName("Charles", (eRealm)2);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>("Charles", (eRealm)2);
             if (npcs.Length == 0)
             {
                 Charles = new DOL.GS.GameNPC();

--- a/GameServerScripts/quests/Midgard/CityOfJordheim.cs
+++ b/GameServerScripts/quests/Midgard/CityOfJordheim.cs
@@ -161,7 +161,7 @@ namespace DOL.GS.Quests.Midgard
 
 			dalikor = GetDalikor();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Jarl Yuliwyf", eRealm.Midgard);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Jarl Yuliwyf", eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				yuliwyf = new GameNPC();
@@ -190,7 +190,7 @@ namespace DOL.GS.Quests.Midgard
 			else
 				yuliwyf = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Harlfug", eRealm.Midgard);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Harlfug", eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				harlfug = new GameStableMaster();

--- a/GameServerScripts/quests/Midgard/Collection.cs
+++ b/GameServerScripts/quests/Midgard/Collection.cs
@@ -150,7 +150,7 @@ namespace DOL.GS.Quests.Midgard
 			GameNPC[] npcs = null;
 			for (int i = 0; i < general.Length; i++)
 			{
-				npcs = WorldMgr.GetNPCsByName(generalNames[i], eRealm.None);
+				npcs = WorldMgr.GetObjectsByName<GameNPC>(generalNames[i], eRealm.None);
 				if (npcs.Length > 0)
 					general[i] = npcs[0] as GameNPC;
 				else

--- a/GameServerScripts/quests/Midgard/Culmination.cs
+++ b/GameServerScripts/quests/Midgard/Culmination.cs
@@ -153,7 +153,7 @@ namespace DOL.GS.Quests.Midgard
 
 			dalikor = GetDalikor();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Queen Vuuna", eRealm.None);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Queen Vuuna", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Midgard/Essence_of_Life.cs
+++ b/GameServerScripts/quests/Midgard/Essence_of_Life.cs
@@ -110,7 +110,7 @@ using DOL.AI.Brain;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-			npcs = WorldMgr.GetNPCsByName("Ambient Rat Statua",(eRealm) 0);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Ambient Rat Statua",(eRealm) 0);
 			if (npcs.Length == 0)
 			{			
 				AmbientRatStatua = new DOL.GS.GameNPC();
@@ -151,7 +151,7 @@ using DOL.AI.Brain;
 				AmbientRatStatua = npcs[0];
 			}
 		
-			npcs = WorldMgr.GetNPCsByName("Ballach",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Ballach",(eRealm) 2);
 			if (npcs.Length == 0)
 			{			
 				Ballach = new DOL.GS.GameNPC();

--- a/GameServerScripts/quests/Midgard/Frontiers.cs
+++ b/GameServerScripts/quests/Midgard/Frontiers.cs
@@ -160,7 +160,7 @@ namespace DOL.GS.Quests.Midgard
 
 			dalikor = GetDalikor();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Stor Gothi Annark", eRealm.Midgard);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Stor Gothi Annark", eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -193,7 +193,7 @@ namespace DOL.GS.Quests.Midgard
 			else
 				annark = npcs[0];
 
-            npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.Frontiers.NPCScryerIdora"), eRealm.Midgard);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.Frontiers.NPCScryerIdora"), eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)
@@ -250,7 +250,7 @@ namespace DOL.GS.Quests.Midgard
 			ticketToSvasudFaste = CreateTicketTo("Svasud Faste", "hs_mularn_svasudfaste");
 			ticketToMularn = CreateTicketTo("Mularn", "hs_svasudfaste_mularn");
 
-            npcs = (GameNPC[])WorldMgr.GetObjectsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.Frontiers.NPCGriffinHandlerNjiedi"), eRealm.Midgard, typeof(GameStableMaster));
+            npcs = WorldMgr.GetObjectsByName<GameStableMaster>(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.Frontiers.NPCGriffinHandlerNjiedi"), eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				njiedi = new GameStableMaster();
@@ -349,7 +349,7 @@ namespace DOL.GS.Quests.Midgard
 				griffin.AddToWorld();
 			}
 
-			npcs = (GameNPC[]) WorldMgr.GetObjectsByName("Vorgar", eRealm.Midgard, typeof (GameStableMaster));
+			npcs = WorldMgr.GetObjectsByName<GameStableMaster>("Vorgar", eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				vorgar = new GameStableMaster();

--- a/GameServerScripts/quests/Midgard/ImportantDelivery.cs
+++ b/GameServerScripts/quests/Midgard/ImportantDelivery.cs
@@ -146,7 +146,7 @@ namespace DOL.GS.Quests.Midgard
 
 			dalikor = GetDalikor();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Abohas", eRealm.Midgard);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Abohas", eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				abohas = new GameNPC();
@@ -174,7 +174,7 @@ namespace DOL.GS.Quests.Midgard
 			else
 				abohas = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Harlfug", eRealm.Midgard);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Harlfug", eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				harlfug = new GameStableMaster();
@@ -203,7 +203,7 @@ namespace DOL.GS.Quests.Midgard
 			else
 				harlfug = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Gularg", eRealm.Midgard);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Gularg", eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				gularg = new GameStableMaster();
@@ -233,7 +233,7 @@ namespace DOL.GS.Quests.Midgard
 			else
 				gularg = npcs[0];
 
-			npcs = WorldMgr.GetNPCsByName("Yolafson", eRealm.Midgard);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Yolafson", eRealm.Midgard);
 			if (npcs.Length == 0)
 			{
 				yolafson = new GameStableMaster();

--- a/GameServerScripts/quests/Midgard/Learn_The_Hunt.cs
+++ b/GameServerScripts/quests/Midgard/Learn_The_Hunt.cs
@@ -106,7 +106,7 @@ using DOL.AI.Brain;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-			npcs = WorldMgr.GetNPCsByName("Aegan",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Aegan",(eRealm) 2);
 			if (npcs.Length == 0)
 			{			
 				Aegan = new DOL.GS.GameNPC();

--- a/GameServerScripts/quests/Midgard/Mauler_Invasion.cs
+++ b/GameServerScripts/quests/Midgard/Mauler_Invasion.cs
@@ -107,7 +107,7 @@ using log4net;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-            npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.MaulerInvasion.NPCKreimhilde"), (eRealm)2);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.MaulerInvasion.NPCKreimhilde"), (eRealm)2);
 
 			if (npcs.Length == 0)
 			{			

--- a/GameServerScripts/quests/Midgard/Mead_Run.cs
+++ b/GameServerScripts/quests/Midgard/Mead_Run.cs
@@ -110,7 +110,7 @@ using DOL.AI.Brain;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-			npcs = WorldMgr.GetNPCsByName("Audun",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Audun",(eRealm) 2);
 			if (npcs.Length == 0)
 			{
 				if (!WorldMgr.GetRegion(101).IsDisabled)
@@ -155,7 +155,7 @@ using DOL.AI.Brain;
 				Audun = npcs[0];
 			}
 		
-			npcs = WorldMgr.GetNPCsByName("Guard Olja",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Guard Olja",(eRealm) 2);
 			if (npcs.Length == 0)
 			{
 				if (!WorldMgr.GetRegion(229).IsDisabled)

--- a/GameServerScripts/quests/Midgard/Rindas_Lost_Key.cs
+++ b/GameServerScripts/quests/Midgard/Rindas_Lost_Key.cs
@@ -112,7 +112,7 @@ using DOL.AI.Brain;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-			npcs = WorldMgr.GetNPCsByName("Dwarven Guard Rinda",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Dwarven Guard Rinda",(eRealm) 2);
 			if (npcs.Length == 0)
 			{
 				if (!WorldMgr.GetRegion(100).IsDisabled)
@@ -157,7 +157,7 @@ using DOL.AI.Brain;
 				DwarvenGuardRinda = npcs[0];
 			}
 		
-			npcs = WorldMgr.GetNPCsByName("hobgoblin snake-finder",(eRealm) 0);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("hobgoblin snake-finder",(eRealm) 0);
 			if (npcs.Length == 0)
 			{
 				if (!WorldMgr.GetRegion(100).IsDisabled)

--- a/GameServerScripts/quests/Midgard/StolenEggs.cs
+++ b/GameServerScripts/quests/Midgard/StolenEggs.cs
@@ -150,7 +150,7 @@ namespace DOL.GS.Quests.Midgard
 
 			dalikor = GetDalikor();
 
-            GameNPC[] npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.StolenEggs.NPCVikingHyndla"), eRealm.Midgard);
+            GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.StolenEggs.NPCVikingHyndla"), eRealm.Midgard);
             if (npcs.Length == 0)
 			{
 				hyndla = new GameNPC();
@@ -180,7 +180,7 @@ namespace DOL.GS.Quests.Midgard
 			else
 				hyndla = npcs[0];
 
-            npcs = (GameNPC[])WorldMgr.GetObjectsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.StolenEggs.NPCGriffinHandlerNjiedi"), eRealm.Midgard, typeof(GameStableMaster));
+            npcs = WorldMgr.GetObjectsByName<GameStableMaster>(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.StolenEggs.NPCGriffinHandlerNjiedi"), eRealm.Midgard);
 
 			if (npcs.Length == 0)
 			{
@@ -229,8 +229,8 @@ namespace DOL.GS.Quests.Midgard
 				njiedi = npcs[0] as GameStableMaster;
 			}
 
-//			npcs = WorldMgr.GetNPCsByName("Askefruer Trainer", eRealm.None);
-            npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.StolenEggs.NPCAskefruerTrainer"), eRealm.None);
+//			npcs = WorldMgr.GetObjectsByName<GameNPC>("Askefruer Trainer", eRealm.None);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.StolenEggs.NPCAskefruerTrainer"), eRealm.None);
             if (npcs.Length == 0)
 			{
 				askefruerTrainer = new GameNPC();

--- a/GameServerScripts/quests/Midgard/Sveabone_Hilt_Sword.cs
+++ b/GameServerScripts/quests/Midgard/Sveabone_Hilt_Sword.cs
@@ -110,7 +110,7 @@ using DOL.AI.Brain;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-			npcs = WorldMgr.GetNPCsByName("Gridash",(eRealm) 2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Gridash",(eRealm) 2);
 			if (npcs.Length == 0)
 			{
 				if (!WorldMgr.GetRegion(100).IsDisabled)

--- a/GameServerScripts/quests/Midgard/The_Birthday_Gift.cs
+++ b/GameServerScripts/quests/Midgard/The_Birthday_Gift.cs
@@ -110,7 +110,7 @@ using log4net;
 	#region defineNPCs
 	GameNPC[] npcs;
 	
-            npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.TheBirthdayGift.NPCBarkeepNognar"), (eRealm)2);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.TheBirthdayGift.NPCBarkeepNognar"), (eRealm)2);
 
 			if (npcs.Length == 0)
 			{
@@ -155,7 +155,7 @@ using log4net;
 				BarkeepNognar = npcs[0];
 			}
 		
-            npcs = WorldMgr.GetNPCsByName(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.TheBirthdayGift.NPCBarkeepPrugar"), (eRealm)2);
+            npcs = WorldMgr.GetObjectsByName<GameNPC>(LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "Mid.TheBirthdayGift.NPCBarkeepPrugar"), (eRealm)2);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Midgard/TraitorInMularn.cs
+++ b/GameServerScripts/quests/Midgard/TraitorInMularn.cs
@@ -142,7 +142,7 @@ namespace DOL.GS.Quests.Midgard
 
 			dalikor = GetDalikor();
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lady Hinda", eRealm.None);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Lady Hinda", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				//if (Log.IsWarnEnabled) Log.Warn("Could not find Lady Hinda, creating her ...");

--- a/GameServerScripts/quests/Midgard/Trial_of_Strength.cs
+++ b/GameServerScripts/quests/Midgard/Trial_of_Strength.cs
@@ -113,7 +113,7 @@ namespace DOL.GS.Quests.Midgard
 			#region defineNPCs
 			GameNPC[] npcs;
 
-			npcs = WorldMgr.GetNPCsByName("Torold Sterkkriger", (eRealm)2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Torold Sterkkriger", (eRealm)2);
 			if (npcs.Length == 0)
 			{
 				if (!WorldMgr.GetRegion(151).IsDisabled)
@@ -158,7 +158,7 @@ namespace DOL.GS.Quests.Midgard
 				ToroldSterkkriger = npcs[0];
 			}
 
-			npcs = WorldMgr.GetNPCsByName("Jorund Bruttstein", (eRealm)2);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Jorund Bruttstein", (eRealm)2);
 			if (npcs.Length == 0)
 			{
 				if (!WorldMgr.GetRegion(151).IsDisabled)

--- a/GameServerScripts/quests/Midgard/epic/MidgardRogue50.cs
+++ b/GameServerScripts/quests/Midgard/epic/MidgardRogue50.cs
@@ -100,7 +100,7 @@ namespace DOL.GS.Quests.Midgard
 
 			#region defineNPCs
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Masrim", eRealm.Midgard);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Masrim", eRealm.Midgard);
 
 			if (npcs.Length == 0)
 			{
@@ -129,7 +129,7 @@ namespace DOL.GS.Quests.Midgard
 				Masrim = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Oona", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Oona", eRealm.None);
 
 			if (npcs.Length == 0)
 			{
@@ -159,7 +159,7 @@ namespace DOL.GS.Quests.Midgard
 				Oona = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Morlin Caan", eRealm.Midgard);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Morlin Caan", eRealm.Midgard);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Midgard/epic/Mystic50.cs
+++ b/GameServerScripts/quests/Midgard/epic/Mystic50.cs
@@ -117,7 +117,7 @@ namespace DOL.GS.Quests.Midgard
 
 			#region defineNPCs
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Danica", eRealm.Midgard);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Danica", eRealm.Midgard);
 
 			if (npcs.Length == 0)
 			{
@@ -145,7 +145,7 @@ namespace DOL.GS.Quests.Midgard
 				Danica = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Kelic", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Kelic", eRealm.None);
 			if (npcs.Length == 0)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Midgard/epic/Seer50.cs
+++ b/GameServerScripts/quests/Midgard/epic/Seer50.cs
@@ -101,7 +101,7 @@ namespace DOL.GS.Quests.Midgard
 
 			#region defineNPCs
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Inaksha", eRealm.Midgard);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Inaksha", eRealm.Midgard);
 
 			if (npcs.Length == 0)
 			{
@@ -130,7 +130,7 @@ namespace DOL.GS.Quests.Midgard
 				Inaksha = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Loken", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Loken", eRealm.None);
 
 			if (npcs.Length == 0)
 			{
@@ -159,7 +159,7 @@ namespace DOL.GS.Quests.Midgard
 				Loken = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Miri", eRealm.Midgard);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Miri", eRealm.Midgard);
 
 			if (npcs.Length == 0)
 			{

--- a/GameServerScripts/quests/Midgard/epic/Viking50.cs
+++ b/GameServerScripts/quests/Midgard/epic/Viking50.cs
@@ -130,7 +130,7 @@ namespace DOL.GS.Quests.Midgard
 
 			#region defineNPCs
 
-			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lynnleigh", eRealm.Midgard);
+			GameNPC[] npcs = WorldMgr.GetObjectsByName<GameNPC>("Lynnleigh", eRealm.Midgard);
 
 			if (npcs.Length == 0)
 			{
@@ -157,7 +157,7 @@ namespace DOL.GS.Quests.Midgard
 			else
 				Lynnleigh = npcs[0];
 			// end npc
-			npcs = WorldMgr.GetNPCsByName("Elizabeth", eRealm.Midgard);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Elizabeth", eRealm.Midgard);
 
 			if (npcs.Length == 0)
 			{
@@ -186,7 +186,7 @@ namespace DOL.GS.Quests.Midgard
 				Elizabeth = npcs[0];
 			// end npc
 
-			npcs = WorldMgr.GetNPCsByName("Ydenia of Seithkona", eRealm.None);
+			npcs = WorldMgr.GetObjectsByName<GameNPC>("Ydenia of Seithkona", eRealm.None);
 
 			if (npcs.Length == 0)
 			{


### PR DESCRIPTION
Switch Getobjects methods to be generic. This removes the multiple casts done per call. Also removes the reflection method building.

Remove unused items from WorldMgr